### PR TITLE
Add sanitization and public display class

### DIFF
--- a/admin/class-admin-settings.php
+++ b/admin/class-admin-settings.php
@@ -19,31 +19,107 @@ class Barramento_Tainacan_Admin_Settings {
      */
     public function register_settings() {
         // Grupo de configurações gerais
-        register_setting('barramento_general_settings', 'barramento_archivematica_url');
-        register_setting('barramento_general_settings', 'barramento_archivematica_user');
-        register_setting('barramento_general_settings', 'barramento_archivematica_api_key');
-        register_setting('barramento_general_settings', 'barramento_storage_service_url');
-        register_setting('barramento_general_settings', 'barramento_storage_service_user');
-        register_setting('barramento_general_settings', 'barramento_storage_service_api_key');
-        register_setting('barramento_general_settings', 'barramento_debug_mode');
+        register_setting(
+            'barramento_general_settings',
+            'barramento_archivematica_url',
+            array('sanitize_callback' => array($this, 'sanitize_url'))
+        );
+        register_setting(
+            'barramento_general_settings',
+            'barramento_archivematica_user',
+            array('sanitize_callback' => 'sanitize_text_field')
+        );
+        register_setting(
+            'barramento_general_settings',
+            'barramento_archivematica_api_key',
+            array('sanitize_callback' => 'sanitize_text_field')
+        );
+        register_setting(
+            'barramento_general_settings',
+            'barramento_storage_service_url',
+            array('sanitize_callback' => array($this, 'sanitize_url'))
+        );
+        register_setting(
+            'barramento_general_settings',
+            'barramento_storage_service_user',
+            array('sanitize_callback' => 'sanitize_text_field')
+        );
+        register_setting(
+            'barramento_general_settings',
+            'barramento_storage_service_api_key',
+            array('sanitize_callback' => 'sanitize_text_field')
+        );
+        register_setting(
+            'barramento_general_settings',
+            'barramento_debug_mode',
+            array('sanitize_callback' => array($this, 'sanitize_boolean'))
+        );
 
         // Grupo de configurações de preservação
-        register_setting('barramento_preservation_settings', 'barramento_max_sip_size');
-        register_setting('barramento_preservation_settings', 'barramento_schedule_frequency');
-        register_setting('barramento_preservation_settings', 'barramento_schedule_time');
-        register_setting('barramento_preservation_settings', 'barramento_hash_algorithm');
-        register_setting('barramento_preservation_settings', 'barramento_retry_attempts');
-        
+        register_setting(
+            'barramento_preservation_settings',
+            'barramento_max_sip_size',
+            array('sanitize_callback' => array($this, 'sanitize_int'))
+        );
+        register_setting(
+            'barramento_preservation_settings',
+            'barramento_schedule_frequency',
+            array('sanitize_callback' => 'sanitize_text_field')
+        );
+        register_setting(
+            'barramento_preservation_settings',
+            'barramento_schedule_time',
+            array('sanitize_callback' => 'sanitize_text_field')
+        );
+        register_setting(
+            'barramento_preservation_settings',
+            'barramento_hash_algorithm',
+            array('sanitize_callback' => 'sanitize_text_field')
+        );
+        register_setting(
+            'barramento_preservation_settings',
+            'barramento_retry_attempts',
+            array('sanitize_callback' => array($this, 'sanitize_int'))
+        );
+
         // Grupo de configurações de coleções
-        register_setting('barramento_collections_settings', 'barramento_enabled_collections');
-        register_setting('barramento_collections_settings', 'barramento_metadata_mapping');
-        register_setting('barramento_collections_settings', 'barramento_required_metadata');
-        register_setting('barramento_collections_settings', 'barramento_fixed_metadata');
-        
+        register_setting(
+            'barramento_collections_settings',
+            'barramento_enabled_collections',
+            array('sanitize_callback' => array($this, 'sanitize_ids'))
+        );
+        register_setting(
+            'barramento_collections_settings',
+            'barramento_metadata_mapping',
+            array('sanitize_callback' => array($this, 'sanitize_textarea'))
+        );
+        register_setting(
+            'barramento_collections_settings',
+            'barramento_required_metadata',
+            array('sanitize_callback' => array($this, 'sanitize_textarea'))
+        );
+        register_setting(
+            'barramento_collections_settings',
+            'barramento_fixed_metadata',
+            array('sanitize_callback' => array($this, 'sanitize_textarea'))
+        );
+
         // Grupo de configurações de relatórios
-        register_setting('barramento_reports_settings', 'barramento_public_page_enabled');
-        register_setting('barramento_reports_settings', 'barramento_public_page_slug');
-        register_setting('barramento_reports_settings', 'barramento_public_display_options');
+        register_setting(
+            'barramento_reports_settings',
+            'barramento_public_page_enabled',
+            array('sanitize_callback' => array($this, 'sanitize_boolean'))
+        );
+        register_setting(
+            'barramento_reports_settings',
+            'barramento_public_page_slug',
+            array('sanitize_callback' => array($this, 'sanitize_slug'))
+        );
+        register_setting(
+            'barramento_reports_settings',
+            'barramento_public_display_options',
+            array('sanitize_callback' => array($this, 'sanitize_textarea'))
+        );
     }
 
     /**
@@ -188,5 +264,68 @@ class Barramento_Tainacan_Admin_Settings {
             'message' => __('Status atualizado com sucesso.', 'barramento-tainacan'),
             'details' => $result
         ));
+    }
+
+    /**
+     * Sanitiza valores booleanos.
+     *
+     * @param mixed $value Valor a ser sanitizado.
+     * @return bool
+     */
+    public function sanitize_boolean( $value ) {
+        return (bool) $value;
+    }
+
+    /**
+     * Sanitiza inteiros.
+     *
+     * @param mixed $value Valor a ser sanitizado.
+     * @return int
+     */
+    public function sanitize_int( $value ) {
+        return absint( $value );
+    }
+
+    /**
+     * Sanitiza URLs.
+     *
+     * @param string $value Valor a ser sanitizado.
+     * @return string
+     */
+    public function sanitize_url( $value ) {
+        return esc_url_raw( $value );
+    }
+
+    /**
+     * Sanitiza arrays de IDs.
+     *
+     * @param mixed $value Valor a ser sanitizado.
+     * @return array
+     */
+    public function sanitize_ids( $value ) {
+        if ( ! is_array( $value ) ) {
+            $value = array();
+        }
+        return array_map( 'absint', $value );
+    }
+
+    /**
+     * Sanitiza textos longos/áreas de texto.
+     *
+     * @param string $value Valor a ser sanitizado.
+     * @return string
+     */
+    public function sanitize_textarea( $value ) {
+        return sanitize_textarea_field( $value );
+    }
+
+    /**
+     * Sanitiza slugs.
+     *
+     * @param string $value Valor a ser sanitizado.
+     * @return string
+     */
+    public function sanitize_slug( $value ) {
+        return sanitize_title( $value );
     }
 }

--- a/admin/views/logs.php
+++ b/admin/views/logs.php
@@ -125,7 +125,7 @@ $base_url = admin_url('admin.php?page=barramento-tainacan-logs');
                                         <span class="dashicons dashicons-arrow-down-alt2"></span>
                                     </button>
                                     <div class="log-context" id="context-<?php echo esc_attr($log['id']); ?>" style="display: none;">
-                                        <pre><?php echo esc_html(json_encode($log['context'], JSON_PRETTY_PRINT)); ?></pre>
+                                        <pre><?php echo esc_html(wp_json_encode($log['context'], JSON_PRETTY_PRINT)); ?></pre>
                                     </div>
                                 <?php endif; ?>
                             </td>

--- a/includes/class-archivematica-api.php
+++ b/includes/class-archivematica-api.php
@@ -238,7 +238,7 @@ class Barramento_Tainacan_Archivematica_API {
         );
         
         if ($method === 'POST' || $method === 'PUT') {
-            $args['body'] = json_encode($data);
+            $args['body'] = wp_json_encode($data);
         } elseif (!empty($data) && $method === 'GET') {
             $url = add_query_arg($data, $url);
         }

--- a/includes/class-db-manager.php
+++ b/includes/class-db-manager.php
@@ -163,7 +163,7 @@ class Barramento_Tainacan_DB_Manager {
             KEY item_id (item_id),
             KEY hash_type (hash_type),
             KEY hash_value (hash_value(191)),
-            CONSTRAINT fk_object_id FOREIGN KEY (object_id) REFERENCES " . $this->table_prefix . "objects(id) ON DELETE CASCADE
+            CONSTRAINT fk_object_id FOREIGN KEY (object_id) REFERENCES {$this->table_prefix}objects(id) ON DELETE CASCADE
         ) $charset_collate;";
 
         require_once(ABSPATH . 'wp-admin/includes/upgrade.php');

--- a/includes/class-logger.php
+++ b/includes/class-logger.php
@@ -58,7 +58,7 @@ class Barramento_Tainacan_Logger {
         $aip_id = isset($context['aip_id']) ? sanitize_text_field($context['aip_id']) : null;
         
         // Serializa o resto do contexto
-        $context_serialized = !empty($context) ? json_encode($context) : null;
+        $context_serialized = !empty($context) ? wp_json_encode($context) : null;
         
         // Insere o log no banco de dados
         $result = $wpdb->insert(

--- a/includes/class-processor.php
+++ b/includes/class-processor.php
@@ -511,9 +511,9 @@ class Barramento_Tainacan_Processor {
             if (!empty($object['notes'])) {
                 $notes = json_decode($object['notes'], true);
                 $notes['transfer_uuid'] = $additional_data['transfer_uuid'];
-                $data['notes'] = json_encode($notes);
+                $data['notes'] = wp_json_encode($notes);
             } else {
-                $data['notes'] = json_encode(array('transfer_uuid' => $additional_data['transfer_uuid']));
+                $data['notes'] = wp_json_encode(array('transfer_uuid' => $additional_data['transfer_uuid']));
             }
         }
         
@@ -634,7 +634,7 @@ class Barramento_Tainacan_Processor {
                         array(
                             'transfer_status' => 'COMPLETE',
                             'ingest_status' => 'started',
-                            'notes' => json_encode(array(
+                            'notes' => wp_json_encode(array(
                                 'transfer_uuid' => $transfer_uuid,
                                 'sip_uuid' => $transfer_status['sip_uuid']
                             ))
@@ -672,7 +672,7 @@ class Barramento_Tainacan_Processor {
                     'transfer_failed',
                     array(
                         'transfer_status' => $status,
-                        'notes' => json_encode(array(
+                        'notes' => wp_json_encode(array(
                             'transfer_uuid' => $transfer_uuid,
                             'message' => $transfer_status['message'] ?? 'Unknown error'
                         ))
@@ -763,7 +763,7 @@ class Barramento_Tainacan_Processor {
                             'ingest_status' => 'COMPLETE',
                             'aip_id' => $aip_info['uuid'],
                             'archivematica_url' => $aip_info['url'] ?? null,
-                            'notes' => json_encode(array(
+                            'notes' => wp_json_encode(array(
                                 'sip_uuid' => $sip_uuid,
                                 'aip_uuid' => $aip_info['uuid'],
                                 'aip_details' => $aip_info
@@ -803,7 +803,7 @@ class Barramento_Tainacan_Processor {
                     'ingest_failed',
                     array(
                         'ingest_status' => $status,
-                        'notes' => json_encode(array(
+                        'notes' => wp_json_encode(array(
                             'sip_uuid' => $sip_uuid,
                             'message' => $ingest_status['message'] ?? 'Unknown error'
                         ))
@@ -930,7 +930,7 @@ class Barramento_Tainacan_Processor {
                     array(
                         'transfer_status' => 'COMPLETE',
                         'ingest_status' => 'started',
-                        'notes' => json_encode(array(
+                        'notes' => wp_json_encode(array(
                             'transfer_uuid' => $status_data['uuid'] ?? $object['notes']['transfer_uuid'] ?? '',
                             'sip_uuid' => $status_data['sip_uuid']
                         ))
@@ -951,7 +951,7 @@ class Barramento_Tainacan_Processor {
                 'transfer_failed',
                 array(
                     'transfer_status' => $status,
-                    'notes' => json_encode(array(
+                    'notes' => wp_json_encode(array(
                         'transfer_uuid' => $status_data['uuid'] ?? $object['notes']['transfer_uuid'] ?? '',
                         'message' => $status_data['message'] ?? 'Unknown error'
                     ))
@@ -986,7 +986,7 @@ class Barramento_Tainacan_Processor {
                             'ingest_status' => 'COMPLETE',
                             'aip_id' => $aip_info['uuid'],
                             'archivematica_url' => $aip_info['url'] ?? null,
-                            'notes' => json_encode(array(
+                            'notes' => wp_json_encode(array(
                                 'sip_uuid' => $sip_uuid,
                                 'aip_uuid' => $aip_info['uuid'],
                                 'aip_details' => $aip_info
@@ -1011,7 +1011,7 @@ class Barramento_Tainacan_Processor {
                 'ingest_failed',
                 array(
                     'ingest_status' => $status,
-                    'notes' => json_encode(array(
+                    'notes' => wp_json_encode(array(
                         'sip_uuid' => $notes['sip_uuid'] ?? '',
                         'message' => $status_data['message'] ?? 'Unknown error'
                     ))

--- a/includes/class-sip-generator.php
+++ b/includes/class-sip-generator.php
@@ -141,7 +141,7 @@ class Barramento_Tainacan_SIP_Generator {
             file_put_contents($mets_file_path, $mets_metadata);
             
             // Gera um arquivo JSON com todos os metadados do Tainacan
-            $tainacan_json = json_encode($item, JSON_PRETTY_PRINT);
+            $tainacan_json = wp_json_encode($item, JSON_PRETTY_PRINT);
             $tainacan_json_path = trailingslashit($submissions_dir) . 'tainacan_metadata.json';
             file_put_contents($tainacan_json_path, $tainacan_json);
             
@@ -578,7 +578,7 @@ class Barramento_Tainacan_SIP_Generator {
             'sip_creation_date' => current_time('mysql'),
             'last_status_update' => current_time('mysql'),
             'batch_id' => $sip_info['batch_id'],
-            'notes' => json_encode($sip_info)
+            'notes' => wp_json_encode($sip_info)
         );
         
         $format = array(

--- a/public/class-public-display.php
+++ b/public/class-public-display.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Funcionalidades públicas do Barramento Tainacan
+ *
+ * @package Barramento_Tainacan
+ */
+
+// Impede acesso direto
+if ( ! defined( 'WPINC' ) ) {
+    die;
+}
+
+/**
+ * Responsável por registrar scripts, estilos e shortcodes públicos.
+ */
+class Barramento_Tainacan_Public_Display {
+
+    /**
+     * Construtor.
+     */
+    public function __construct() {
+        require_once BARRAMENTO_TAINACAN_PLUGIN_DIR . 'public/view/preservation-status.php';
+        require_once BARRAMENTO_TAINACAN_PLUGIN_DIR . 'public/collection-status.php';
+    }
+
+    /**
+     * Carrega os estilos públicos.
+     */
+    public function enqueue_styles() {
+        wp_enqueue_style(
+            'barramento-public',
+            BARRAMENTO_TAINACAN_PLUGIN_URL . 'public/css/barramento-public.css',
+            array(),
+            BARRAMENTO_TAINACAN_VERSION
+        );
+    }
+
+    /**
+     * Carrega os scripts públicos.
+     */
+    public function enqueue_scripts() {
+        wp_enqueue_script(
+            'barramento-public',
+            BARRAMENTO_TAINACAN_PLUGIN_URL . 'public/js/barramento-public.js',
+            array( 'jquery' ),
+            BARRAMENTO_TAINACAN_VERSION,
+            true
+        );
+
+        wp_localize_script(
+            'barramento-public',
+            'barramento_public',
+            array(
+                'ajax_url' => admin_url( 'admin-ajax.php' ),
+                'nonce'    => wp_create_nonce( 'barramento_public_nonce' ),
+                'i18n'     => array(
+                    'aip_id'       => __( 'AIP ID:', 'barramento-tainacan' ),
+                    'preserved_on' => __( 'Preservado em:', 'barramento-tainacan' ),
+                    'reason'       => __( 'Motivo:', 'barramento-tainacan' ),
+                    'retry_note'   => __( 'Entre em contato com o administrador para reprocessar este item.', 'barramento-tainacan' ),
+                ),
+            )
+        );
+    }
+
+    /**
+     * Shortcode para exibir o status de preservação de um item.
+     *
+     * @param array $atts Atributos do shortcode.
+     * @return string
+     */
+    public function preservation_status_shortcode( $atts ) {
+        $atts = shortcode_atts(
+            array(
+                'item_id' => 0,
+                'details' => true,
+            ),
+            $atts,
+            'barramento_status'
+        );
+
+        $show_details = filter_var( $atts['details'], FILTER_VALIDATE_BOOLEAN );
+
+        return barramento_tainacan_display_preservation_status( intval( $atts['item_id'] ), $show_details );
+    }
+
+    /**
+     * Shortcode para exibir o status de preservação de uma coleção.
+     *
+     * @param array $atts Atributos do shortcode.
+     * @return string
+     */
+    public function collection_status_shortcode( $atts ) {
+        return barramento_collection_status_shortcode( $atts );
+    }
+}


### PR DESCRIPTION
## Summary
- fix SQL table constraint interpolation
- add missing public display class and wire shortcodes
- sanitize plugin settings and switch to wp_json_encode

## Testing
- `php -l includes/class-db-manager.php`
- `php -l public/class-public-display.php`
- `php -l admin/class-admin-settings.php`
- `php -l includes/class-logger.php`
- `php -l admin/views/logs.php`
- `php -l includes/class-archivematica-api.php`
- `php -l includes/class-sip-generator.php`
- `php -l includes/class-processor.php`


------
https://chatgpt.com/codex/tasks/task_e_689368a357048330ba1531bcb0397e51